### PR TITLE
Implement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+target
+node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # kindle-publication-check
+
+A lambda for checking the status of the Guardian's Kindle publication.
+
+Tests that:
+1. the url for the current issue correctly redirects to an S3 path with today's date
+2. the number of articles is above a certain threshold
+
+If the tests pass, an email is sent with the article and image counts.
+If the tests fail, an email is sent with the cause.

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -31,10 +31,10 @@ Parameters:
     Description: Source email address
     Type: String
   PassTargetAddresses:
-    Description: Target email addresses to use when tests pass
+    Description: Comma-separated list of target email addresses to use when tests pass
     Type: String
   FailureTargetAddresses:
-    Description: Target email addresses to use when tests fail
+    Description: Comma-separated list of target email addresses to use when tests fail
     Type: String
   MinimumArticleCount:
     Description: Minimum expected articles in an edition

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,0 +1,80 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: Checks the status of Kindle publication and sends emails
+
+Parameters:
+  Stack:
+    Description: Stack name
+    Type: String
+    Default: content-api
+  App:
+    Description: Application name
+    Type: String
+    Default: kindle-publication-check
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+  DeployBucket:
+    Description: Bucket to copy files to
+    Type: String
+    Default: content-api-dist
+  ManifestURL:
+    Description: URL of the latest manifest file (should redirect)
+    Type: String
+  KindleBucket:
+    Description: S3 bucket with the generated kindle files
+    Type: String
+  SourceAddress:
+    Description: Source email address
+    Type: String
+  PassTargetAddresses:
+    Description: Target email addresses to use when tests pass
+    Type: String
+  FailureTargetAddresses:
+    Description: Target email addresses to use when tests fail
+    Type: String
+  MinimumArticleCount:
+    Description: Minimum expected articles in an edition
+    Type: Number
+Resources:
+  Lambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${App}-${Stage}
+      Description: Checks the status of Kindle publication and sends emails
+      Runtime: nodejs8.10
+      Handler: lambda.handler
+      MemorySize: 128
+      Timeout: 300
+      Environment:
+        Variables:
+          ManifestURL: !Ref ManifestURL
+          KindleBucket: !Ref KindleBucket
+          Stage: !Ref Stage
+          SourceAddress: !Ref SourceAddress
+          PassTargetAddresses: !Ref PassTargetAddresses
+          FailureTargetAddresses: !Ref FailureTargetAddresses
+          MinimumArticleCount: !Ref MinimumArticleCount
+      CodeUri:
+        Bucket: !Ref DeployBucket
+        Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Statement:
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !Sub "arn:aws:s3::*:${KindleBucket}"
+        - Statement:
+            Effect: Allow
+            Action:
+              - ses:SendEmail
+            Resource:
+              - "*"
+            Condition:
+              StringEquals:
+                ses:FromAddress: !Ref SourceAddress

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kindle-publication-check",
+  "isAwsLambda": true,
+  "cloudformation": false,
+  "projectName": "Off Platform::kindle-publication-check",
+  "buildDir": "./target",
+  "riffraffFile": "./riff-raff.yaml",
+  "dependencies": {
+    "aws-sdk": "^2.264.1",
+    "typescript": "2.8.3",
+    "moment": "2.22.2"
+  },
+  "devDependencies": {
+    "@types/node": "8.10.0",
+    "node-riffraff-artefact": "^2.0.1"
+  },
+  "scripts": {
+    "clean": "rm -rf target",
+    "build": "tsc",
+    "local": "node target/local.js",
+    "package": "ARTEFACT_PATH=$PWD/target VERBOSE=true riffraff-artefact"
+  }
+}

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,4 +1,4 @@
-stacks: [content-api-]
+stacks: [content-api]
 regions: [eu-west-1]
 
 deployments:

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,11 @@
+stacks: [content-api-]
+regions: [eu-west-1]
+
+deployments:
+  kindle-publication-check:
+    type: aws-lambda
+    parameters:
+      prefixStack: false
+      bucket: content-api-dist
+      fileName: kindle-publication-check.zip
+      functionNames: [kindle-publication-check-]

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 let moment = require('moment');
+import { URL } from "url"
 
 export class Config {
-    ManifestURL: string = process.env.ManifestURL;
+    ManifestURL: URL = new URL(process.env.ManifestURL);
     KindleBucket: string = process.env.KindleBucket;
     Stage: string = process.env.Stage;
     SourceAddress: string = process.env.SourceAddress;

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,8 +6,8 @@ export class Config {
     KindleBucket: string = process.env.KindleBucket;
     Stage: string = process.env.Stage;
     SourceAddress: string = process.env.SourceAddress;
-    PassTargetAddresses: string[] = process.env.PassTargetAddresses.split(',');
-    FailureTargetAddresses: string[] = process.env.FailureTargetAddresses.split(',');
+    PassTargetAddresses: string[] = process.env.PassTargetAddresses.split(',').map(a => a.trim());
+    FailureTargetAddresses: string[] = process.env.FailureTargetAddresses.split(',').map(a => a.trim());
     MinimumArticleCount: number = parseInt(process.env.MinimumArticleCount);
 
     Today: string = moment().format('YYYY-MM-DD');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,13 @@
+let moment = require('moment');
+
+export class Config {
+    ManifestURL: string = process.env.ManifestURL;
+    KindleBucket: string = process.env.KindleBucket;
+    Stage: string = process.env.Stage;
+    SourceAddress: string = process.env.SourceAddress;
+    PassTargetAddresses: string[] = process.env.PassTargetAddresses.split(',');
+    FailureTargetAddresses: string[] = process.env.FailureTargetAddresses.split(',');
+    MinimumArticleCount: number = parseInt(process.env.MinimumArticleCount);
+
+    Today: string = moment().format('YYYY-MM-DD');
+}

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -100,13 +100,13 @@ let sendEmail = (subject: string, body: string, targetAddresses: string[]): Prom
 };
 
 let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> => sendEmail(
-    'Kindle publication succeeded',
+    `Kindle publication succeeded (${config.Today})`,
     `The Kindle edition for ${config.Today} was successfully published.\nIt contains ${info.articleCount} articles with ${info.imageCount} images.`,
     config.PassTargetAddresses
 );
 
 let sendFailureEmail = (error: string): Promise<SendEmailResponse> => sendEmail(
-    'Kindle publication failed',
+    `Kindle publication FAILED (${config.Today})`,
     `The Kindle edition for ${config.Today} was not successfully published. The error was: \n'${error}'`,
     config.FailureTargetAddresses
 );

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -73,16 +73,15 @@ let getS3Objects = (bucket: string, prefix: string): Promise<ListObjectsOutput> 
 };
 
 let validatePublicationInfo = (result: ListObjectsOutput): Promise<PublicationInfo> => {
-    let articles: S3.Object[] = result.Contents.filter(object => object.Key.endsWith('.nitf.xml'));
-    let images: S3.Object[] = result.Contents.filter(object => object.Key.endsWith('.jpg'));
+    let info: PublicationInfo = {
+        articleCount: result.Contents.filter(object => object.Key.endsWith('.nitf.xml')).length,
+        imageCount: result.Contents.filter(object => object.Key.endsWith('.jpg')).length
+    };
 
-    if (articles.length >= config.MinimumArticleCount) {
-        return Promise.resolve({
-            articleCount: articles.length,
-            imageCount: images.length
-        })
+    if (info.articleCount >= config.MinimumArticleCount) {
+        return Promise.resolve(info)
     } else {
-        return Promise.reject(`Expected at least ${config.MinimumArticleCount} articles, but there are only ${articles.length}`)
+        return Promise.reject(`Expected at least ${config.MinimumArticleCount} articles, but there are only ${info.articleCount}`)
     }
 };
 

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,0 +1,106 @@
+import {ListObjectsOutput} from 'aws-sdk/clients/s3';
+import {SendEmailRequest, SendEmailResponse} from 'aws-sdk/clients/ses';
+import {Config} from './config';
+import S3 = require("aws-sdk/clients/s3");
+
+let http = require('http');
+let AWS = require('aws-sdk');
+let s3 = new AWS.S3();
+let ses = new AWS.SES({region: 'eu-west-1'});
+let config = new Config();
+
+type Url = string
+type PublicationInfo = {
+    articleCount: number
+    imageCount: number
+}
+
+export async function handler(): Promise<SendEmailResponse> {
+    return getRedirect(config.ManifestURL)
+        .then(testRedirect)
+        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}`))
+        .then(validatePublicationInfo)
+        .then(sendSuccessEmail)
+        .catch(sendFailureEmail)
+}
+
+//Returns the redirect url, and also checks that it contains today's date
+let getRedirect = (url: Url): Promise<Url> => {
+    return new Promise((resolve, reject) => {
+        http.get(url, response => {
+            if (response.statusCode === 302) {
+                if (response.headers.location.includes(config.Today))
+                    resolve(response.headers.location);
+                else
+                    reject(`Expected today's date (${config.Today}), but got ${response.headers.location}`)
+            } else {
+                reject(`Expected status code 302 (moved permanently) for url ${url}, got ${response.statusCode}`)
+            }
+        })
+    })
+};
+
+let testRedirect = (url: Url): Promise<number> => {
+    return new Promise((resolve, reject) => {
+        http.get(url, response => {
+            if (response.statusCode === 200)
+                resolve(response.statusCode);
+            else
+                reject(`Expected status code 200 for url ${url}, got ${response.statusCode}`)
+        })
+    })
+};
+
+let getS3Objects = (bucket: string, prefix: string): Promise<ListObjectsOutput> => {
+    return s3.listObjects({
+        Bucket: bucket,
+        Prefix: prefix
+    }).promise()
+};
+
+let validatePublicationInfo = (result: ListObjectsOutput): Promise<PublicationInfo> => {
+    let articles: S3.Object[] = result.Contents.filter(object => object.Key.endsWith('.nitf.xml'));
+    let images: S3.Object[] = result.Contents.filter(object => object.Key.endsWith('.jpg'));
+
+    if (articles.length >= config.MinimumArticleCount) {
+        return Promise.resolve({
+            articleCount: articles.length,
+            imageCount: images.length
+        })
+    } else {
+        return Promise.reject(`Expected at least ${config.MinimumArticleCount} articles, but there are only ${articles.length}`)
+    }
+};
+
+let sendEmail = (message: string, targetAddresses: string[]): Promise<SendEmailResponse> => {
+    let request: SendEmailRequest = {
+        Destination: {
+            ToAddresses: targetAddresses
+        },
+        Message: {
+            Subject: {
+                Charset: 'UTF-8',
+                Data: 'Kindle publication succeeded'
+            },
+            Body: {
+                Text: {
+                    Charset: 'UTF-8',
+                    Data: message
+                }
+            }
+        },
+        Source: config.SourceAddress
+    };
+
+    return ses.sendEmail(request).promise()
+};
+
+let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> => sendEmail(
+    `The Kindle edition for ${config.Today} was successfully published.\nIt contains ${info.articleCount} articles with ${info.imageCount} images.`,
+    config.PassTargetAddresses
+);
+
+let sendFailureEmail = (error: string): Promise<SendEmailResponse> => sendEmail(
+    `The Kindle edition for ${config.Today} was not successfully published. The error was: \n'${error}'`,
+    config.FailureTargetAddresses
+);

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -15,6 +15,10 @@ type PublicationInfo = {
     imageCount: number
 }
 
+/**
+ * The AWS Lambda handler function.
+ * Runs a series of checks against today's Kindle publication, then sends an email
+ */
 export async function handler(): Promise<SendEmailResponse> {
     return getRedirect(config.ManifestURL)
         .then(testRedirect)
@@ -72,7 +76,7 @@ let validatePublicationInfo = (result: ListObjectsOutput): Promise<PublicationIn
     }
 };
 
-let sendEmail = (message: string, targetAddresses: string[]): Promise<SendEmailResponse> => {
+let sendEmail = (subject: string, body: string, targetAddresses: string[]): Promise<SendEmailResponse> => {
     let request: SendEmailRequest = {
         Destination: {
             ToAddresses: targetAddresses
@@ -80,12 +84,12 @@ let sendEmail = (message: string, targetAddresses: string[]): Promise<SendEmailR
         Message: {
             Subject: {
                 Charset: 'UTF-8',
-                Data: 'Kindle publication succeeded'
+                Data: subject
             },
             Body: {
                 Text: {
                     Charset: 'UTF-8',
-                    Data: message
+                    Data: body
                 }
             }
         },
@@ -96,11 +100,13 @@ let sendEmail = (message: string, targetAddresses: string[]): Promise<SendEmailR
 };
 
 let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> => sendEmail(
+    'Kindle publication succeeded',
     `The Kindle edition for ${config.Today} was successfully published.\nIt contains ${info.articleCount} articles with ${info.imageCount} images.`,
     config.PassTargetAddresses
 );
 
 let sendFailureEmail = (error: string): Promise<SendEmailResponse> => sendEmail(
+    'Kindle publication failed',
     `The Kindle edition for ${config.Today} was not successfully published. The error was: \n'${error}'`,
     config.FailureTargetAddresses
 );

--- a/src/local.ts
+++ b/src/local.ts
@@ -1,0 +1,21 @@
+import { handler } from './lambda';
+let AWS = require('aws-sdk');
+
+/**
+ * For testing locally:
+ * `yarn run local`
+ */
+
+AWS.config = new AWS.Config();
+AWS.config.accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+AWS.config.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
+AWS.config.region = "eu-west-1";
+
+async function run() {
+    await handler()
+        .then(result => console.log(result))
+        .catch(err => console.log(err))
+}
+
+run();

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+npm install -g yarn
+
+yarn install
+# Will place .js files in target
+yarn run build
+
+# These also need to be in the RiffRaff package
+cp package.json target
+cp riff-raff.yaml target
+
+pushd target
+# Ensures the RiffRaff package has the node_modules needed to run
+yarn install --production
+popd
+
+yarn run package

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "target",
+    "sourceMap": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
A lambda for checking the status of the Guardian's Kindle publication.

Tests that:
1. the url for the current issue correctly redirects to an S3 path with today's date
2. the number of articles is above a certain threshold

If the tests pass, an email is sent with the article and image counts.
If the tests fail, an email is sent with the cause.

TODO - add cloudwatch schedule to run every night