### PR TITLE
Schedule

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -39,6 +39,14 @@ Parameters:
   MinimumArticleCount:
     Description: Minimum expected articles in an edition
     Type: Number
+  RunHours:
+    Description: Comma-separated list of hours in which the lambda should run (because cloudwatch only allows UTC)
+    Type: String
+    Default: "0,1"
+  TimeZone:
+    Description: Timezone the environment should adopt (because cloudwatch only allows UTC)
+    Type: String
+    Default: "Europe/London"
 Resources:
   Lambda:
     Type: AWS::Serverless::Function
@@ -58,6 +66,8 @@ Resources:
           PassTargetAddresses: !Ref PassTargetAddresses
           FailureTargetAddresses: !Ref FailureTargetAddresses
           MinimumArticleCount: !Ref MinimumArticleCount
+          RunHours: !Ref RunHours
+          TZ: !Ref TimeZone
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -88,3 +88,18 @@ Resources:
             Condition:
               StringEquals:
                 ses:FromAddress: !Ref SourceAddress
+
+      # These events run 6 mins after the kindle-gen lambda
+      Events:
+        DailyGMTRun:
+          Type: Schedule
+          Properties:
+            Schedule: cron(16 1 * * ? *)  # Run at 01:16 AM GMT (UTC+0) every day
+        DailyBSTRunGMTPrerun:
+          Type: Schedule
+          Properties:
+            Schedule: cron(16 0 * * ? *)  # Run at 12:16 AM GMT (UTC+0) / 01:16 AM BST (UTC+1) every day
+        DailyBSTPrerun:
+          Type: Schedule
+          Properties:
+            Schedule: cron(16 23 * * ? *)  # Run at 12:16 AM BST (UTC+1) every day

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export class Config {
     PassTargetAddresses: string[] = process.env.PassTargetAddresses.split(',').map(a => a.trim());
     FailureTargetAddresses: string[] = process.env.FailureTargetAddresses.split(',').map(a => a.trim());
     MinimumArticleCount: number = parseInt(process.env.MinimumArticleCount);
+    RunHours: number[] = process.env.RunHours.split(',').map(h => parseInt(h.trim()));
 
     Today: string = moment().format('YYYY-MM-DD');
 }

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -23,19 +23,20 @@ type PublicationInfo = {
 export async function handler(): Promise<SendEmailResponse | string> {
     let currentHour = new Date().getHours();
 
-    if (shouldRun(currentHour)) {
-        return getRedirect(config.ManifestURL)
-            .then(testRedirect)
-            .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}`))
-            .then(validatePublicationInfo)
-            .then(sendSuccessEmail)
-            .catch(sendFailureEmail)
-    } else {
-        return Promise.resolve(`Not running because hour is ${currentHour}`)
-    }
+    if (shouldRun(currentHour)) return run();
+    else return Promise.resolve(`Not running because hour is ${currentHour}`)
 }
 
 let shouldRun = (currentHour: number): boolean => config.RunHours.indexOf(currentHour) >= 0;
+
+let run = (): Promise<SendEmailResponse> => {
+    return getRedirect(config.ManifestURL)
+        .then(testRedirect)
+        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}`))
+        .then(validatePublicationInfo)
+        .then(sendSuccessEmail)
+        .catch(sendFailureEmail)
+};
 
 let headRequestOptions = (url: URL): RequestOptions => {
     return {


### PR DESCRIPTION
Run 6 mins after kindle-gen - https://github.com/guardian/kindle-gen/blob/master/cfn.yaml#L83

Timezones+daylight savings are impossible to reason about, but essentially there are 3 events because we have a pre-run and a main run, and also need to respect GMT+BST.