### PR TITLE
Fix article count

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -29,10 +29,15 @@ export async function handler(): Promise<SendEmailResponse | string> {
 
 let shouldRun = (currentHour: number): boolean => config.RunHours.indexOf(currentHour) >= 0;
 
+let currentHourString = () => {
+    let currentHour = new Date().getHours();
+    currentHour.toString.length == 1 ? `0${currentHour}00` : `${currentHour}00`;
+};
+
 let run = (): Promise<SendEmailResponse> => {
     return getRedirect(config.ManifestURL)
         .then(testRedirect)
-        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}`))
+        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}/${currentHourString()}`))
         .then(validatePublicationInfo)
         .then(sendSuccessEmail)
         .catch(sendFailureEmail)

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -29,10 +29,8 @@ export async function handler(): Promise<SendEmailResponse | string> {
 
 let shouldRun = (currentHour: number): boolean => config.RunHours.indexOf(currentHour) >= 0;
 
-let currentHourString = () => {
-    let currentHour = new Date().getHours();
-    currentHour.toString.length == 1 ? `0${currentHour}00` : `${currentHour}00`;
-};
+//This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
+let currentHourString = () => new Date().getHours() === 0 ? "0000" : "0100";
 
 let run = (): Promise<SendEmailResponse> => {
     return getRedirect(config.ManifestURL)


### PR DESCRIPTION
Previously it was counting all files under e.g. `/PROD/2018-01-01/`, when it should be `/PROD/2018-01-01/0100/`. This meant it was picking up counts from the pre-run as well