### PR TITLE
Refactor to ensure config is not shared across lambda invocations

### DIFF
--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -1,0 +1,119 @@
+import {ListObjectsOutput} from 'aws-sdk/clients/s3';
+import {SendEmailRequest, SendEmailResponse} from 'aws-sdk/clients/ses';
+import {Config} from './config';
+import {RequestOptions} from "http";
+import { URL } from "url"
+
+let http = require('http');
+let AWS = require('aws-sdk');
+let s3 = new AWS.S3();
+let ses = new AWS.SES({region: 'eu-west-1'});
+
+type PublicationInfo = {
+    articleCount: number
+    imageCount: number
+}
+
+export function checkPublication(config: Config): Promise<SendEmailResponse> {
+
+    //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
+    let currentHourString = () => new Date().getHours() === 0 ? "0000" : "0100";
+
+    let headRequestOptions = (url: URL): RequestOptions => {
+        return {
+            host: url.hostname,
+            path: url.pathname,
+            method: 'HEAD',
+            protocol: url.protocol
+        }
+    };
+
+    //Returns the redirect url, and also checks that it contains today's date
+    let getRedirect = (url: URL): Promise<URL> => {
+        return new Promise((resolve, reject) => {
+            http.request(headRequestOptions(url), response => {
+                if (response.statusCode === 302) {
+                    if (response.headers.location.includes(config.Today))
+                        resolve(new URL(response.headers.location));
+                    else
+                        reject(`Expected today's date (${config.Today}), but got ${response.headers.location}`)
+                } else {
+                    reject(`Expected status code 302 (moved permanently) for url ${url}, got ${response.statusCode}`)
+                }
+            }).end()
+        })
+    };
+
+    let testRedirect = (url: URL): Promise<number> => {
+        return new Promise((resolve, reject) => {
+            http.request(headRequestOptions(url), response => {
+                if (response.statusCode === 200)
+                    resolve(response.statusCode);
+                else
+                    reject(`Expected status code 200 for url ${url}, got ${response.statusCode}`)
+            }).end()
+        })
+    };
+
+    let getS3Objects = (bucket: string, prefix: string): Promise<ListObjectsOutput> => {
+        return s3.listObjects({
+            Bucket: bucket,
+            Prefix: prefix
+        }).promise()
+    };
+
+    let validatePublicationInfo = (result: ListObjectsOutput): Promise<PublicationInfo> => {
+        let info: PublicationInfo = {
+            articleCount: result.Contents.filter(object => object.Key.endsWith('.nitf.xml')).length,
+            imageCount: result.Contents.filter(object => object.Key.endsWith('.jpg')).length
+        };
+
+        if (info.articleCount >= config.MinimumArticleCount) {
+            return Promise.resolve(info)
+        } else {
+            return Promise.reject(`Expected at least ${config.MinimumArticleCount} articles, but there are only ${info.articleCount}`)
+        }
+    };
+
+    let sendEmail = (subject: string, body: string, targetAddresses: string[]): Promise<SendEmailResponse> => {
+        let request: SendEmailRequest = {
+            Destination: {
+                ToAddresses: targetAddresses
+            },
+            Message: {
+                Subject: {
+                    Charset: 'UTF-8',
+                    Data: subject
+                },
+                Body: {
+                    Text: {
+                        Charset: 'UTF-8',
+                        Data: body
+                    }
+                }
+            },
+            Source: config.SourceAddress
+        };
+
+        return ses.sendEmail(request).promise()
+    };
+
+    let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> => sendEmail(
+        `Kindle publication succeeded (${config.Today})`,
+        `The Kindle edition for ${config.Today} was successfully published.\nIt contains ${info.articleCount} articles with ${info.imageCount} images.`,
+        config.PassTargetAddresses
+    );
+
+    let sendFailureEmail = (error: string): Promise<SendEmailResponse> => sendEmail(
+        `Kindle publication FAILED (${config.Today})`,
+        `The Kindle edition for ${config.Today} was not successfully published. The error was: \n'${error}'`,
+        config.FailureTargetAddresses
+    );
+
+    return getRedirect(config.ManifestURL)
+        .then(testRedirect)
+        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}/${currentHourString()}`))
+        .then(validatePublicationInfo)
+        .then(sendSuccessEmail)
+        .catch(sendFailureEmail)
+}

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,20 +1,6 @@
-import {ListObjectsOutput} from 'aws-sdk/clients/s3';
-import {SendEmailRequest, SendEmailResponse} from 'aws-sdk/clients/ses';
+import {SendEmailResponse} from 'aws-sdk/clients/ses';
 import {Config} from './config';
-import S3 = require("aws-sdk/clients/s3");
-import {RequestOptions} from "http";
-import { URL } from "url"
-
-let http = require('http');
-let AWS = require('aws-sdk');
-let s3 = new AWS.S3();
-let ses = new AWS.SES({region: 'eu-west-1'});
-let config = new Config();
-
-type PublicationInfo = {
-    articleCount: number
-    imageCount: number
-}
+import {checkPublication} from "./checkPublication";
 
 /**
  * The AWS Lambda handler function.
@@ -23,111 +9,10 @@ type PublicationInfo = {
 export async function handler(): Promise<SendEmailResponse | string> {
     let currentHour = new Date().getHours();
 
-    if (shouldRun(currentHour)) return run();
+    let config = new Config();
+
+    let shouldRun = config.RunHours.indexOf(currentHour) >= 0;
+
+    if (shouldRun) return checkPublication(config);
     else return Promise.resolve(`Not running because hour is ${currentHour}`)
 }
-
-let shouldRun = (currentHour: number): boolean => config.RunHours.indexOf(currentHour) >= 0;
-
-//This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
-let currentHourString = () => new Date().getHours() === 0 ? "0000" : "0100";
-
-let run = (): Promise<SendEmailResponse> => {
-    return getRedirect(config.ManifestURL)
-        .then(testRedirect)
-        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}/${currentHourString()}`))
-        .then(validatePublicationInfo)
-        .then(sendSuccessEmail)
-        .catch(sendFailureEmail)
-};
-
-let headRequestOptions = (url: URL): RequestOptions => {
-    return {
-        host: url.hostname,
-        path: url.pathname,
-        method: 'HEAD',
-        protocol: url.protocol
-    }
-};
-
-//Returns the redirect url, and also checks that it contains today's date
-let getRedirect = (url: URL): Promise<URL> => {
-    return new Promise((resolve, reject) => {
-        http.request(headRequestOptions(url), response => {
-            if (response.statusCode === 302) {
-                if (response.headers.location.includes(config.Today))
-                    resolve(new URL(response.headers.location));
-                else
-                    reject(`Expected today's date (${config.Today}), but got ${response.headers.location}`)
-            } else {
-                reject(`Expected status code 302 (moved permanently) for url ${url}, got ${response.statusCode}`)
-            }
-        }).end()
-    })
-};
-
-let testRedirect = (url: URL): Promise<number> => {
-    return new Promise((resolve, reject) => {
-        http.request(headRequestOptions(url), response => {
-            if (response.statusCode === 200)
-                resolve(response.statusCode);
-            else
-                reject(`Expected status code 200 for url ${url}, got ${response.statusCode}`)
-        }).end()
-    })
-};
-
-let getS3Objects = (bucket: string, prefix: string): Promise<ListObjectsOutput> => {
-    return s3.listObjects({
-        Bucket: bucket,
-        Prefix: prefix
-    }).promise()
-};
-
-let validatePublicationInfo = (result: ListObjectsOutput): Promise<PublicationInfo> => {
-    let info: PublicationInfo = {
-        articleCount: result.Contents.filter(object => object.Key.endsWith('.nitf.xml')).length,
-        imageCount: result.Contents.filter(object => object.Key.endsWith('.jpg')).length
-    };
-
-    if (info.articleCount >= config.MinimumArticleCount) {
-        return Promise.resolve(info)
-    } else {
-        return Promise.reject(`Expected at least ${config.MinimumArticleCount} articles, but there are only ${info.articleCount}`)
-    }
-};
-
-let sendEmail = (subject: string, body: string, targetAddresses: string[]): Promise<SendEmailResponse> => {
-    let request: SendEmailRequest = {
-        Destination: {
-            ToAddresses: targetAddresses
-        },
-        Message: {
-            Subject: {
-                Charset: 'UTF-8',
-                Data: subject
-            },
-            Body: {
-                Text: {
-                    Charset: 'UTF-8',
-                    Data: body
-                }
-            }
-        },
-        Source: config.SourceAddress
-    };
-
-    return ses.sendEmail(request).promise()
-};
-
-let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> => sendEmail(
-    `Kindle publication succeeded (${config.Today})`,
-    `The Kindle edition for ${config.Today} was successfully published.\nIt contains ${info.articleCount} articles with ${info.imageCount} images.`,
-    config.PassTargetAddresses
-);
-
-let sendFailureEmail = (error: string): Promise<SendEmailResponse> => sendEmail(
-    `Kindle publication FAILED (${config.Today})`,
-    `The Kindle edition for ${config.Today} was not successfully published. The error was: \n'${error}'`,
-    config.FailureTargetAddresses
-);


### PR DESCRIPTION
Despite the large diff, this change does 2 small things:
1. Creates the `Config` object inside the lambda `handler`, to prevent config being shared across AWS lambda invocations (this caused an issue where an earlier date was being incorrectly used again).
2. For clarity,  moves everything except the `handler` function from `lambda.ts` to a function in a new file, `checkPublication.ts`.

@aware @philmcmahon