### PR TITLE
Add ReturnPath in sendMail

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -30,6 +30,9 @@ Parameters:
   SourceAddress:
     Description: Source email address
     Type: String
+  ReturnPath:
+    Description: Email address for bounces (must be set for SPF authentication)
+    Type: String
   PassTargetAddresses:
     Description: Comma-separated list of target email addresses to use when tests pass
     Type: String

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -92,7 +92,8 @@ export function checkPublication(config: Config): Promise<SendEmailResponse> {
                     }
                 }
             },
-            Source: config.SourceAddress
+            Source: config.SourceAddress,
+            ReturnPath: config.ReturnPath
         };
 
         return ses.sendEmail(request).promise()

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export class Config {
     KindleBucket: string = process.env.KindleBucket;
     Stage: string = process.env.Stage;
     SourceAddress: string = process.env.SourceAddress;
+    ReturnPath: string = process.env.ReturnPath;
     PassTargetAddresses: string[] = process.env.PassTargetAddresses.split(',').map(a => a.trim());
     FailureTargetAddresses: string[] = process.env.FailureTargetAddresses.split(',').map(a => a.trim());
     MinimumArticleCount: number = parseInt(process.env.MinimumArticleCount);


### PR DESCRIPTION
This will address current authentication issues which cause emails sent by this lambda to be flagged as SPAM by our filters. The reason and solution are explained in [this guide](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/mail-from.html).