### PR TITLE
Report on failures in logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,117 @@
+{
+  "name": "kindle-publication-check",
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@types/node": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.0.tgz",
+      "integrity": "sha512-7IGHZQfRfa0bCd7zUBVUGFKFn31SpaLDFfNoCAqkTGQO5JlHC9BwQA/CG9KZlABFxIUtXznyFgechjPQEGrUTg==",
+      "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.458.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.458.0.tgz",
+      "integrity": "sha512-KcP5zA+zrIvQvPafjyPodIlmcwp5mX2VbsMF4ajp02k2IxdL/QiWv0dTU1cZEqb/G4B4LupJX1X2Slx6ZVb8cw==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "typescript": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.1",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "buildDir": "./target",
   "riffraffFile": "./riff-raff.yaml",
   "dependencies": {
-    "aws-sdk": "^2.264.1",
-    "typescript": "2.8.3",
-    "moment": "2.22.2"
+    "aws-sdk": "^2.458.0",
+    "moment": "^2.24.0",
+    "typescript": "^3.4.5"
   },
   "devDependencies": {
-    "@types/node": "8.10.0",
+    "@types/node": "^8.10.0",
     "node-riffraff-artefact": "^2.0.1"
   },
   "scripts": {

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -1,166 +1,163 @@
 import { ListObjectsOutput } from "aws-sdk/clients/s3";
 import { SendEmailRequest, SendEmailResponse } from "aws-sdk/clients/ses";
 import { Config } from "./config";
-import { RequestOptions } from "http";
 import { URL } from "url";
+import AWS from "aws-sdk";
+import { request, RequestOptions } from "http";
 
-let http = require("http");
-let AWS = require("aws-sdk");
 let s3 = new AWS.S3();
 let ses = new AWS.SES({ region: "eu-west-1" });
 let logs = new AWS.CloudWatchLogs();
 
 type PublicationInfo = {
-  articleCount: number;
-  imageCount: number;
+    articleCount: number;
+    imageCount: number;
 };
 
 export function checkPublication(config: Config): Promise<SendEmailResponse> {
-  //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
-  let currentHourString = () => (new Date().getHours() === 0 ? "0000" : "0100");
+    //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
+    let currentHourString = () => (new Date().getHours() === 0 ? "0000" : "0100");
 
-  let headRequestOptions = (url: URL): RequestOptions => {
-    return {
-      host: url.hostname,
-      path: url.pathname,
-      method: "HEAD",
-      protocol: url.protocol
-    };
-  };
-
-  //Returns the redirect url, and also checks that it contains today's date
-  let getRedirect = (url: URL): Promise<URL> => {
-    return new Promise((resolve, reject) => {
-      http
-        .request(headRequestOptions(url), response => {
-          if (response.statusCode === 302) {
-            if (response.headers.location.includes(config.Today))
-              resolve(new URL(response.headers.location));
-            else
-              reject(
-                `Expected today's date (${config.Today}), but got ${
-                  response.headers.location
-                }`
-              );
-          } else {
-            reject(
-              `Expected status code 302 (moved permanently) for url ${url}, got ${
-                response.statusCode
-              }`
-            );
-          }
-        })
-        .end();
-    });
-  };
-
-  let testRedirect = (url: URL): Promise<number> => {
-    return new Promise((resolve, reject) => {
-      http
-        .request(headRequestOptions(url), response => {
-          if (response.statusCode === 200) resolve(response.statusCode);
-          else
-            reject(
-              `Expected status code 200 for url ${url}, got ${
-                response.statusCode
-              }`
-            );
-        })
-        .end();
-    });
-  };
-
-  let getS3Objects = (
-    bucket: string,
-    prefix: string
-  ): Promise<ListObjectsOutput> => {
-    return s3
-      .listObjects({
-        Bucket: bucket,
-        Prefix: prefix
-      })
-      .promise();
-  };
-
-  let validatePublicationInfo = (
-    result: ListObjectsOutput
-  ): Promise<PublicationInfo> => {
-    let info: PublicationInfo = {
-      articleCount: result.Contents.filter(object =>
-        object.Key.endsWith(".nitf.xml")
-      ).length,
-      imageCount: result.Contents.filter(object => object.Key.endsWith(".jpg"))
-        .length
+    let headRequestOptions = (url: URL): RequestOptions => {
+        return {
+            host: url.hostname,
+            path: url.pathname,
+            method: "HEAD",
+            protocol: url.protocol
+        };
     };
 
-    if (info.articleCount >= config.MinimumArticleCount) {
-      return Promise.resolve(info);
-    } else {
-      return Promise.reject(
-        `Expected at least ${
-          config.MinimumArticleCount
-        } articles, but there are only ${info.articleCount}`
-      );
-    }
-  };
+    //Returns the redirect url, and also checks that it contains today's date
+    let getRedirect = (url: URL): Promise<URL> => {
+        return new Promise((resolve, reject) => {
+            request(headRequestOptions(url), response => {
+                if (response.statusCode === 302) {
+                    if (response.headers.location.includes(config.Today))
+                        resolve(new URL(response.headers.location));
+                    else
+                        reject(
+                            `Expected today's date (${config.Today}), but got ${
+                            response.headers.location
+                            }`
+                        );
+                } else {
+                    reject(
+                        `Expected status code 302 (moved permanently) for url ${url}, got ${
+                        response.statusCode
+                        }`
+                    );
+                }
+            })
+                .end();
+        });
+    };
 
-  let sendEmail = (
-    subject: string,
-    body: string,
-    targetAddresses: string[]
-  ): Promise<SendEmailResponse> => {
-    let request: SendEmailRequest = {
-      Destination: {
-        ToAddresses: targetAddresses
-      },
-      Message: {
-        Subject: {
-          Charset: "UTF-8",
-          Data: subject
-        },
-        Body: {
-          Text: {
-            Charset: "UTF-8",
-            Data: body
-          }
+    let testRedirect = (url: URL): Promise<number> => {
+        return new Promise((resolve, reject) => {
+            request(headRequestOptions(url), response => {
+                if (response.statusCode === 200) resolve(response.statusCode);
+                else
+                    reject(
+                        `Expected status code 200 for url ${url}, got ${
+                        response.statusCode
+                        }`
+                    );
+            })
+                .end();
+        });
+    };
+
+    let getS3Objects = (
+        bucket: string,
+        prefix: string
+    ): Promise<ListObjectsOutput> => {
+        return s3
+            .listObjects({
+                Bucket: bucket,
+                Prefix: prefix
+            })
+            .promise();
+    };
+
+    let validatePublicationInfo = (
+        result: ListObjectsOutput
+    ): Promise<PublicationInfo> => {
+        let info: PublicationInfo = {
+            articleCount: result.Contents.filter(object =>
+                object.Key.endsWith(".nitf.xml")
+            ).length,
+            imageCount: result.Contents.filter(object => object.Key.endsWith(".jpg"))
+                .length
+        };
+
+        if (info.articleCount >= config.MinimumArticleCount) {
+            return Promise.resolve(info);
+        } else {
+            return Promise.reject(
+                `Expected at least ${
+                config.MinimumArticleCount
+                } articles, but there are only ${info.articleCount}`
+            );
         }
-      },
-      Source: config.SourceAddress,
-      ReturnPath: config.ReturnPath
     };
 
-    return ses.sendEmail(request).promise();
-  };
+    let sendEmail = (
+        subject: string,
+        body: string,
+        targetAddresses: string[]
+    ): Promise<SendEmailResponse> => {
+        let request: SendEmailRequest = {
+            Destination: {
+                ToAddresses: targetAddresses
+            },
+            Message: {
+                Subject: {
+                    Charset: "UTF-8",
+                    Data: subject
+                },
+                Body: {
+                    Text: {
+                        Charset: "UTF-8",
+                        Data: body
+                    }
+                }
+            },
+            Source: config.SourceAddress,
+            ReturnPath: config.ReturnPath
+        };
 
-  let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
-    sendEmail(
-      `Kindle publication succeeded (${config.Today})`,
-      `The Kindle edition for ${
-        config.Today
-      } was successfully published.\nIt contains ${
-        info.articleCount
-      } articles with ${info.imageCount} images.`,
-      config.PassTargetAddresses
-    );
+        return ses.sendEmail(request).promise();
+    };
 
-  let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
-    sendEmail(
-      `Kindle publication FAILED (${config.Today})`,
-      `The Kindle edition for ${
-        config.Today
-      } was not successfully published. The error was: \n'${error}'`,
-      config.FailureTargetAddresses
-    );
+    let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
+        sendEmail(
+            `Kindle publication succeeded (${config.Today})`,
+            `The Kindle edition for ${
+            config.Today
+            } was successfully published.\nIt contains ${
+            info.articleCount
+            } articles with ${info.imageCount} images.`,
+            config.PassTargetAddresses
+        );
 
-  return getRedirect(config.ManifestURL)
-    .then(testRedirect)
-    .then(() =>
-      getS3Objects(
-        config.KindleBucket,
-        `${config.Stage}/${config.Today}/${currentHourString()}`
-      )
-    )
-    .then(validatePublicationInfo)
-    .then(sendSuccessEmail)
-    .catch(sendFailureEmail);
+    let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
+        sendEmail(
+            `Kindle publication FAILED (${config.Today})`,
+            `The Kindle edition for ${
+            config.Today
+            } was not successfully published. The error was: \n'${error}'`,
+            config.FailureTargetAddresses
+        );
+
+    return getRedirect(config.ManifestURL)
+        .then(testRedirect)
+        .then(() =>
+            getS3Objects(
+                config.KindleBucket,
+                `${config.Stage}/${config.Today}/${currentHourString()}`
+            )
+        )
+        .then(validatePublicationInfo)
+        .then(sendSuccessEmail)
+        .catch(sendFailureEmail);
 }

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -2,7 +2,7 @@ import { ListObjectsOutput } from "aws-sdk/clients/s3";
 import { SendEmailRequest, SendEmailResponse } from "aws-sdk/clients/ses";
 import { Config } from "./config";
 import { URL } from "url";
-import AWS from "aws-sdk";
+import * as AWS from "aws-sdk";
 import { request, RequestOptions } from "http";
 
 let s3 = new AWS.S3();
@@ -15,6 +15,8 @@ type PublicationInfo = {
 };
 
 export function checkPublication(config: Config): Promise<SendEmailResponse> {
+    const logGroupName: string = `/aws/lambda/kindle-gen-${config.Stage}`;
+
     //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
     let currentHourString = () => (new Date().getHours() === 0 ? "0000" : "0100");
 
@@ -101,6 +103,52 @@ export function checkPublication(config: Config): Promise<SendEmailResponse> {
         }
     };
 
+    const getLogs = (logGroupName: string): Promise<Array<AWS.CloudWatchLogs.OutputLogEvent>> => findLogStreams(logGroupName).then(getCloudwatchLogs(logGroupName));
+
+    const findLogStreams = (logGroupName: string): Promise<Array<AWS.CloudWatchLogs.LogStream>> => new Promise((resolve, reject) => {
+        logs.describeLogStreams({
+            logGroupName,
+            orderBy: 'LastEventTime',
+            descending: true,
+            limit: 2
+        }, function (err, data) {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(data.logStreams);
+        })
+    });
+
+    const getCloudwatchLogs = (logGroupName: string) => (logStreams: AWS.CloudWatchLogs.LogStream[]): Promise<Array<AWS.CloudWatchLogs.OutputLogEvent>> => {
+        const getLogsFor = (logStream: AWS.CloudWatchLogs.LogStream): Promise<AWS.CloudWatchLogs.OutputLogEvent[]> => new Promise((resolve, reject) => {
+            logs.getLogEvents({
+                logGroupName,
+                logStreamName: logStream.logStreamName,
+                startFromHead: true
+            }, (err, data) => {
+                if (err) {
+                    reject(err);
+                    return;
+                } else if (data.events.length < 20) {
+                    throw new Error(`Log stream ${logStream.logStreamName} in ${logGroupName} only contains ${data.events.length} but we expected hundreds of them`)
+                }
+
+                resolve(data.events);
+            })
+        });
+        return getLogsFor(logStreams[0]).catch(() => getLogsFor(logStreams[1]));
+    }
+
+    const checkLogs = (allLogs: Array<AWS.CloudWatchLogs.OutputLogEvent>): Promise<void> => {
+        const errors = allLogs.filter(log => / WARN | ERROR | FATAL /.test(log.message))
+        if (errors.length > 0) {
+            return Promise.reject(errors)
+        } else {
+            return Promise.resolve();
+        }
+    }
+
     let sendEmail = (
         subject: string,
         body: string,
@@ -151,6 +199,7 @@ export function checkPublication(config: Config): Promise<SendEmailResponse> {
 
     return getRedirect(config.ManifestURL)
         .then(testRedirect)
+        .then(() => getLogs(logGroupName).then(checkLogs))
         .then(() =>
             getS3Objects(
                 config.KindleBucket,

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -10,204 +10,236 @@ let ses = new AWS.SES({ region: "eu-west-1" });
 let logs = new AWS.CloudWatchLogs();
 
 type PublicationInfo = {
-    articleCount: number;
-    imageCount: number;
+  articleCount: number;
+  imageCount: number;
 };
 
 export function checkPublication(config: Config): Promise<SendEmailResponse> {
-    const logGroupName: string = `/aws/lambda/kindle-gen-${config.Stage}`;
+  const logGroupName: string = `/aws/lambda/kindle-gen-${config.Stage}`;
 
-    //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
-    let currentHourString = () => (new Date().getHours() === 0 ? "0000" : "0100");
+  //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
+  let currentHourString = () => (new Date().getHours() === 0 ? "0000" : "0100");
 
-    let headRequestOptions = (url: URL): RequestOptions => {
-        return {
-            host: url.hostname,
-            path: url.pathname,
-            method: "HEAD",
-            protocol: url.protocol
-        };
+  let headRequestOptions = (url: URL): RequestOptions => {
+    return {
+      host: url.hostname,
+      path: url.pathname,
+      method: "HEAD",
+      protocol: url.protocol
     };
+  };
 
-    //Returns the redirect url, and also checks that it contains today's date
-    let getRedirect = (url: URL): Promise<URL> => {
-        return new Promise((resolve, reject) => {
-            request(headRequestOptions(url), response => {
-                if (response.statusCode === 302) {
-                    if (response.headers.location.includes(config.Today))
-                        resolve(new URL(response.headers.location));
-                    else
-                        reject(
-                            `Expected today's date (${config.Today}), but got ${
-                            response.headers.location
-                            }`
-                        );
-                } else {
-                    reject(
-                        `Expected status code 302 (moved permanently) for url ${url}, got ${
-                        response.statusCode
-                        }`
-                    );
-                }
-            })
-                .end();
-        });
-    };
-
-    let testRedirect = (url: URL): Promise<number> => {
-        return new Promise((resolve, reject) => {
-            request(headRequestOptions(url), response => {
-                if (response.statusCode === 200) resolve(response.statusCode);
-                else
-                    reject(
-                        `Expected status code 200 for url ${url}, got ${
-                        response.statusCode
-                        }`
-                    );
-            })
-                .end();
-        });
-    };
-
-    let getS3Objects = (
-        bucket: string,
-        prefix: string
-    ): Promise<ListObjectsOutput> => {
-        return s3
-            .listObjects({
-                Bucket: bucket,
-                Prefix: prefix
-            })
-            .promise();
-    };
-
-    let validatePublicationInfo = (
-        result: ListObjectsOutput
-    ): Promise<PublicationInfo> => {
-        let info: PublicationInfo = {
-            articleCount: result.Contents.filter(object =>
-                object.Key.endsWith(".nitf.xml")
-            ).length,
-            imageCount: result.Contents.filter(object => object.Key.endsWith(".jpg"))
-                .length
-        };
-
-        if (info.articleCount >= config.MinimumArticleCount) {
-            return Promise.resolve(info);
-        } else {
-            return Promise.reject(
-                `Expected at least ${
-                config.MinimumArticleCount
-                } articles, but there are only ${info.articleCount}`
+  //Returns the redirect url, and also checks that it contains today's date
+  let getRedirect = (url: URL): Promise<URL> => {
+    return new Promise((resolve, reject) => {
+      request(headRequestOptions(url), response => {
+        if (response.statusCode === 302) {
+          if (response.headers.location.includes(config.Today))
+            resolve(new URL(response.headers.location));
+          else
+            reject(
+              `Expected today's date (${config.Today}), but got ${
+                response.headers.location
+              }`
             );
+        } else {
+          reject(
+            `Expected status code 302 (moved permanently) for url ${url}, got ${
+              response.statusCode
+            }`
+          );
         }
+      }).end();
+    });
+  };
+
+  let testRedirect = (url: URL): Promise<number> => {
+    return new Promise((resolve, reject) => {
+      request(headRequestOptions(url), response => {
+        if (response.statusCode === 200) resolve(response.statusCode);
+        else
+          reject(
+            `Expected status code 200 for url ${url}, got ${
+              response.statusCode
+            }`
+          );
+      }).end();
+    });
+  };
+
+  let getS3Objects = (
+    bucket: string,
+    prefix: string
+  ): Promise<ListObjectsOutput> => {
+    return s3
+      .listObjects({
+        Bucket: bucket,
+        Prefix: prefix
+      })
+      .promise();
+  };
+
+  let validatePublicationInfo = (
+    result: ListObjectsOutput
+  ): Promise<PublicationInfo> => {
+    let info: PublicationInfo = {
+      articleCount: result.Contents.filter(object =>
+        object.Key.endsWith(".nitf.xml")
+      ).length,
+      imageCount: result.Contents.filter(object => object.Key.endsWith(".jpg"))
+        .length
     };
 
-    const getLogs = (logGroupName: string): Promise<Array<AWS.CloudWatchLogs.OutputLogEvent>> => findLogStreams(logGroupName).then(getCloudwatchLogs(logGroupName));
+    if (info.articleCount >= config.MinimumArticleCount) {
+      return Promise.resolve(info);
+    } else {
+      return Promise.reject(
+        `Expected at least ${
+          config.MinimumArticleCount
+        } articles, but there are only ${info.articleCount}`
+      );
+    }
+  };
 
-    const findLogStreams = (logGroupName: string): Promise<Array<AWS.CloudWatchLogs.LogStream>> => new Promise((resolve, reject) => {
-        logs.describeLogStreams({
-            logGroupName,
-            orderBy: 'LastEventTime',
-            descending: true,
-            limit: 2
-        }, function (err, data) {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(data.logStreams);
-        })
+  const getLogs = (
+    logGroupName: string
+  ): Promise<Array<AWS.CloudWatchLogs.OutputLogEvent>> =>
+    findLogStreams(logGroupName).then(getCloudwatchLogs(logGroupName));
+
+  const findLogStreams = (
+    logGroupName: string
+  ): Promise<Array<AWS.CloudWatchLogs.LogStream>> =>
+    new Promise((resolve, reject) => {
+      logs.describeLogStreams(
+        {
+          logGroupName,
+          orderBy: "LastEventTime",
+          descending: true,
+          limit: 2
+        },
+        function(err, data) {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(data.logStreams);
+        }
+      );
     });
 
-    const getCloudwatchLogs = (logGroupName: string) => (logStreams: AWS.CloudWatchLogs.LogStream[]): Promise<Array<AWS.CloudWatchLogs.OutputLogEvent>> => {
-        const getLogsFor = (logStream: AWS.CloudWatchLogs.LogStream): Promise<AWS.CloudWatchLogs.OutputLogEvent[]> => new Promise((resolve, reject) => {
-            logs.getLogEvents({
-                logGroupName,
-                logStreamName: logStream.logStreamName,
-                startFromHead: true
-            }, (err, data) => {
-                if (err) {
-                    reject(err);
-                    return;
-                } else if (!data.events.some(event => event.message.includes(`Starting to publish files for ${config.Today}`))) {
-                    throw new Error(`Log stream ${logStream.logStreamName} in ${logGroupName} only contains ${data.events.length} but we expected hundreds of them`)
-                }
+  const getCloudwatchLogs = (logGroupName: string) => (
+    logStreams: AWS.CloudWatchLogs.LogStream[]
+  ): Promise<Array<AWS.CloudWatchLogs.OutputLogEvent>> => {
+    const getLogsFor = (
+      logStream: AWS.CloudWatchLogs.LogStream
+    ): Promise<AWS.CloudWatchLogs.OutputLogEvent[]> =>
+      new Promise((resolve, reject) => {
+        logs.getLogEvents(
+          {
+            logGroupName,
+            logStreamName: logStream.logStreamName,
+            startFromHead: true
+          },
+          (err, data) => {
+            if (err) {
+              reject(err);
+              return;
+            } else if (
+              !data.events.some(event =>
+                event.message.includes(
+                  `Starting to publish files for ${config.Today}`
+                )
+              )
+            ) {
+              throw new Error(
+                `Log stream ${
+                  logStream.logStreamName
+                } in ${logGroupName} only contains ${
+                  data.events.length
+                } but we expected hundreds of them`
+              );
+            }
 
-                resolve(data.events);
-            })
-        });
-        return logStreams.reduce((p, logStream) => p.catch(() => getLogsFor(logStream)), Promise.reject());
+            resolve(data.events);
+          }
+        );
+      });
+    return logStreams.reduce(
+      (p, logStream) => p.catch(() => getLogsFor(logStream)),
+      Promise.reject()
+    );
+  };
+
+  const checkLogs = (
+    allLogs: Array<AWS.CloudWatchLogs.OutputLogEvent>
+  ): Promise<void> => {
+    const errorRegexp = /WARN|ERROR|FATAL/;
+    const errors = allLogs.filter(log => errorRegexp.test(log.message));
+    if (errors.length > 0) {
+      return Promise.reject(errors);
+    } else {
+      return Promise.resolve();
     }
+  };
 
-    const checkLogs = (allLogs: Array<AWS.CloudWatchLogs.OutputLogEvent>): Promise<void> => {
-        const errorRegexp = /WARN|ERROR|FATAL/
-        const errors = allLogs.filter(log => errorRegexp.test(log.message))
-        if (errors.length > 0) {
-            return Promise.reject(errors)
-        } else {
-            return Promise.resolve();
+  let sendEmail = (
+    subject: string,
+    body: string,
+    targetAddresses: string[]
+  ): Promise<SendEmailResponse> => {
+    let request: SendEmailRequest = {
+      Destination: {
+        ToAddresses: targetAddresses
+      },
+      Message: {
+        Subject: {
+          Charset: "UTF-8",
+          Data: subject
+        },
+        Body: {
+          Text: {
+            Charset: "UTF-8",
+            Data: body
+          }
         }
-    }
-
-    let sendEmail = (
-        subject: string,
-        body: string,
-        targetAddresses: string[]
-    ): Promise<SendEmailResponse> => {
-        let request: SendEmailRequest = {
-            Destination: {
-                ToAddresses: targetAddresses
-            },
-            Message: {
-                Subject: {
-                    Charset: "UTF-8",
-                    Data: subject
-                },
-                Body: {
-                    Text: {
-                        Charset: "UTF-8",
-                        Data: body
-                    }
-                }
-            },
-            Source: config.SourceAddress,
-            ReturnPath: config.ReturnPath
-        };
-
-        return ses.sendEmail(request).promise();
+      },
+      Source: config.SourceAddress,
+      ReturnPath: config.ReturnPath
     };
 
-    let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
-        sendEmail(
-            `Kindle publication succeeded (${config.Today})`,
-            `The Kindle edition for ${
-            config.Today
-            } was successfully published.\nIt contains ${
-            info.articleCount
-            } articles with ${info.imageCount} images.`,
-            config.PassTargetAddresses
-        );
+    return ses.sendEmail(request).promise();
+  };
 
-    let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
-        sendEmail(
-            `Kindle publication FAILED (${config.Today})`,
-            `The Kindle edition for ${
-            config.Today
-            } was not successfully published. The error was: \n'${error}'`,
-            config.FailureTargetAddresses
-        );
+  let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
+    sendEmail(
+      `Kindle publication succeeded (${config.Today})`,
+      `The Kindle edition for ${
+        config.Today
+      } was successfully published.\nIt contains ${
+        info.articleCount
+      } articles with ${info.imageCount} images.`,
+      config.PassTargetAddresses
+    );
 
-    return getRedirect(config.ManifestURL)
-        .then(testRedirect)
-        .then(() => getLogs(logGroupName).then(checkLogs))
-        .then(() =>
-            getS3Objects(
-                config.KindleBucket,
-                `${config.Stage}/${config.Today}/${currentHourString()}`
-            )
-        )
-        .then(validatePublicationInfo)
-        .then(sendSuccessEmail)
-        .catch(sendFailureEmail);
+  let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
+    sendEmail(
+      `Kindle publication FAILED (${config.Today})`,
+      `The Kindle edition for ${
+        config.Today
+      } was not successfully published. The error was: \n'${error}'`,
+      config.FailureTargetAddresses
+    );
+
+  return getRedirect(config.ManifestURL)
+    .then(testRedirect)
+    .then(() => getLogs(logGroupName).then(checkLogs))
+    .then(() =>
+      getS3Objects(
+        config.KindleBucket,
+        `${config.Stage}/${config.Today}/${currentHourString()}`
+      )
+    )
+    .then(validatePublicationInfo)
+    .then(sendSuccessEmail)
+    .catch(sendFailureEmail);
 }

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -159,15 +159,7 @@ export function checkPublication(
                 )
               )
             ) {
-              reject(
-                new Error(
-                  `Log stream ${
-                    logStream.logStreamName
-                  } in ${logGroupName} only contains ${
-                    data.events.length
-                  } but we expected hundreds of them`
-                )
-              );
+              resolve([]);
             }
 
             resolve(data.events);
@@ -175,8 +167,8 @@ export function checkPublication(
         );
       });
     return logStreams.reduce(
-      (p, logStream) => p.catch(() => getLogsFor(logStream)),
-      Promise.reject()
+      (p, logStream) => p.then(logs => logs.length == 0 ? getLogsFor(logStream) : logs),
+      Promise.resolve([])
     );
   };
 

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -137,7 +137,7 @@ export function checkPublication(config: Config): Promise<SendEmailResponse> {
                 resolve(data.events);
             })
         });
-        return getLogsFor(logStreams[0]).catch(() => getLogsFor(logStreams[1]));
+        return logStreams.reduce((p, logStream) => p.catch(() => getLogsFor(logStream)), Promise.reject());
     }
 
     const checkLogs = (allLogs: Array<AWS.CloudWatchLogs.OutputLogEvent>): Promise<void> => {

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -130,7 +130,7 @@ export function checkPublication(config: Config): Promise<SendEmailResponse> {
                 if (err) {
                     reject(err);
                     return;
-                } else if (data.events.length < 20) {
+                } else if (!data.events.some(event => event.message.includes(`Starting to publish files for ${config.Today}`))) {
                     throw new Error(`Log stream ${logStream.logStreamName} in ${logGroupName} only contains ${data.events.length} but we expected hundreds of them`)
                 }
 

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -141,7 +141,8 @@ export function checkPublication(config: Config): Promise<SendEmailResponse> {
     }
 
     const checkLogs = (allLogs: Array<AWS.CloudWatchLogs.OutputLogEvent>): Promise<void> => {
-        const errors = allLogs.filter(log => / WARN | ERROR | FATAL /.test(log.message))
+        const errorRegexp = /WARN|ERROR|FATAL/
+        const errors = allLogs.filter(log => errorRegexp.test(log.message))
         if (errors.length > 0) {
             return Promise.reject(errors)
         } else {

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -1,120 +1,166 @@
-import {ListObjectsOutput} from 'aws-sdk/clients/s3';
-import {SendEmailRequest, SendEmailResponse} from 'aws-sdk/clients/ses';
-import {Config} from './config';
-import {RequestOptions} from "http";
-import { URL } from "url"
+import { ListObjectsOutput } from "aws-sdk/clients/s3";
+import { SendEmailRequest, SendEmailResponse } from "aws-sdk/clients/ses";
+import { Config } from "./config";
+import { RequestOptions } from "http";
+import { URL } from "url";
 
-let http = require('http');
-let AWS = require('aws-sdk');
+let http = require("http");
+let AWS = require("aws-sdk");
 let s3 = new AWS.S3();
-let ses = new AWS.SES({region: 'eu-west-1'});
+let ses = new AWS.SES({ region: "eu-west-1" });
+let logs = new AWS.CloudWatchLogs();
 
 type PublicationInfo = {
-    articleCount: number
-    imageCount: number
-}
+  articleCount: number;
+  imageCount: number;
+};
 
 export function checkPublication(config: Config): Promise<SendEmailResponse> {
+  //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
+  let currentHourString = () => (new Date().getHours() === 0 ? "0000" : "0100");
 
-    //This lambda runs either after midnight or after 1am. Default to 1am in case we want to manually run later
-    let currentHourString = () => new Date().getHours() === 0 ? "0000" : "0100";
-
-    let headRequestOptions = (url: URL): RequestOptions => {
-        return {
-            host: url.hostname,
-            path: url.pathname,
-            method: 'HEAD',
-            protocol: url.protocol
-        }
+  let headRequestOptions = (url: URL): RequestOptions => {
+    return {
+      host: url.hostname,
+      path: url.pathname,
+      method: "HEAD",
+      protocol: url.protocol
     };
+  };
 
-    //Returns the redirect url, and also checks that it contains today's date
-    let getRedirect = (url: URL): Promise<URL> => {
-        return new Promise((resolve, reject) => {
-            http.request(headRequestOptions(url), response => {
-                if (response.statusCode === 302) {
-                    if (response.headers.location.includes(config.Today))
-                        resolve(new URL(response.headers.location));
-                    else
-                        reject(`Expected today's date (${config.Today}), but got ${response.headers.location}`)
-                } else {
-                    reject(`Expected status code 302 (moved permanently) for url ${url}, got ${response.statusCode}`)
-                }
-            }).end()
+  //Returns the redirect url, and also checks that it contains today's date
+  let getRedirect = (url: URL): Promise<URL> => {
+    return new Promise((resolve, reject) => {
+      http
+        .request(headRequestOptions(url), response => {
+          if (response.statusCode === 302) {
+            if (response.headers.location.includes(config.Today))
+              resolve(new URL(response.headers.location));
+            else
+              reject(
+                `Expected today's date (${config.Today}), but got ${
+                  response.headers.location
+                }`
+              );
+          } else {
+            reject(
+              `Expected status code 302 (moved permanently) for url ${url}, got ${
+                response.statusCode
+              }`
+            );
+          }
         })
-    };
+        .end();
+    });
+  };
 
-    let testRedirect = (url: URL): Promise<number> => {
-        return new Promise((resolve, reject) => {
-            http.request(headRequestOptions(url), response => {
-                if (response.statusCode === 200)
-                    resolve(response.statusCode);
-                else
-                    reject(`Expected status code 200 for url ${url}, got ${response.statusCode}`)
-            }).end()
+  let testRedirect = (url: URL): Promise<number> => {
+    return new Promise((resolve, reject) => {
+      http
+        .request(headRequestOptions(url), response => {
+          if (response.statusCode === 200) resolve(response.statusCode);
+          else
+            reject(
+              `Expected status code 200 for url ${url}, got ${
+                response.statusCode
+              }`
+            );
         })
+        .end();
+    });
+  };
+
+  let getS3Objects = (
+    bucket: string,
+    prefix: string
+  ): Promise<ListObjectsOutput> => {
+    return s3
+      .listObjects({
+        Bucket: bucket,
+        Prefix: prefix
+      })
+      .promise();
+  };
+
+  let validatePublicationInfo = (
+    result: ListObjectsOutput
+  ): Promise<PublicationInfo> => {
+    let info: PublicationInfo = {
+      articleCount: result.Contents.filter(object =>
+        object.Key.endsWith(".nitf.xml")
+      ).length,
+      imageCount: result.Contents.filter(object => object.Key.endsWith(".jpg"))
+        .length
     };
 
-    let getS3Objects = (bucket: string, prefix: string): Promise<ListObjectsOutput> => {
-        return s3.listObjects({
-            Bucket: bucket,
-            Prefix: prefix
-        }).promise()
-    };
+    if (info.articleCount >= config.MinimumArticleCount) {
+      return Promise.resolve(info);
+    } else {
+      return Promise.reject(
+        `Expected at least ${
+          config.MinimumArticleCount
+        } articles, but there are only ${info.articleCount}`
+      );
+    }
+  };
 
-    let validatePublicationInfo = (result: ListObjectsOutput): Promise<PublicationInfo> => {
-        let info: PublicationInfo = {
-            articleCount: result.Contents.filter(object => object.Key.endsWith('.nitf.xml')).length,
-            imageCount: result.Contents.filter(object => object.Key.endsWith('.jpg')).length
-        };
-
-        if (info.articleCount >= config.MinimumArticleCount) {
-            return Promise.resolve(info)
-        } else {
-            return Promise.reject(`Expected at least ${config.MinimumArticleCount} articles, but there are only ${info.articleCount}`)
+  let sendEmail = (
+    subject: string,
+    body: string,
+    targetAddresses: string[]
+  ): Promise<SendEmailResponse> => {
+    let request: SendEmailRequest = {
+      Destination: {
+        ToAddresses: targetAddresses
+      },
+      Message: {
+        Subject: {
+          Charset: "UTF-8",
+          Data: subject
+        },
+        Body: {
+          Text: {
+            Charset: "UTF-8",
+            Data: body
+          }
         }
+      },
+      Source: config.SourceAddress,
+      ReturnPath: config.ReturnPath
     };
 
-    let sendEmail = (subject: string, body: string, targetAddresses: string[]): Promise<SendEmailResponse> => {
-        let request: SendEmailRequest = {
-            Destination: {
-                ToAddresses: targetAddresses
-            },
-            Message: {
-                Subject: {
-                    Charset: 'UTF-8',
-                    Data: subject
-                },
-                Body: {
-                    Text: {
-                        Charset: 'UTF-8',
-                        Data: body
-                    }
-                }
-            },
-            Source: config.SourceAddress,
-            ReturnPath: config.ReturnPath
-        };
+    return ses.sendEmail(request).promise();
+  };
 
-        return ses.sendEmail(request).promise()
-    };
-
-    let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> => sendEmail(
-        `Kindle publication succeeded (${config.Today})`,
-        `The Kindle edition for ${config.Today} was successfully published.\nIt contains ${info.articleCount} articles with ${info.imageCount} images.`,
-        config.PassTargetAddresses
+  let sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
+    sendEmail(
+      `Kindle publication succeeded (${config.Today})`,
+      `The Kindle edition for ${
+        config.Today
+      } was successfully published.\nIt contains ${
+        info.articleCount
+      } articles with ${info.imageCount} images.`,
+      config.PassTargetAddresses
     );
 
-    let sendFailureEmail = (error: string): Promise<SendEmailResponse> => sendEmail(
-        `Kindle publication FAILED (${config.Today})`,
-        `The Kindle edition for ${config.Today} was not successfully published. The error was: \n'${error}'`,
-        config.FailureTargetAddresses
+  let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
+    sendEmail(
+      `Kindle publication FAILED (${config.Today})`,
+      `The Kindle edition for ${
+        config.Today
+      } was not successfully published. The error was: \n'${error}'`,
+      config.FailureTargetAddresses
     );
 
-    return getRedirect(config.ManifestURL)
-        .then(testRedirect)
-        .then(() => getS3Objects(config.KindleBucket, `${config.Stage}/${config.Today}/${currentHourString()}`))
-        .then(validatePublicationInfo)
-        .then(sendSuccessEmail)
-        .catch(sendFailureEmail)
+  return getRedirect(config.ManifestURL)
+    .then(testRedirect)
+    .then(() =>
+      getS3Objects(
+        config.KindleBucket,
+        `${config.Stage}/${config.Today}/${currentHourString()}`
+      )
+    )
+    .then(validatePublicationInfo)
+    .then(sendSuccessEmail)
+    .catch(sendFailureEmail);
 }

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,18 +1,49 @@
-import {SendEmailResponse} from 'aws-sdk/clients/ses';
-import {Config} from './config';
-import {checkPublication} from "./checkPublication";
+import { SendEmailResponse } from "aws-sdk/clients/ses";
+import { Config } from "./config";
+import { checkPublication } from "./checkPublication";
+import * as AWS from "aws-sdk";
+
+let ses = new AWS.SES({ region: "eu-west-1" });
 
 /**
  * The AWS Lambda handler function.
  * Runs a series of checks against today's Kindle publication, then sends an email
  */
-export async function handler(): Promise<SendEmailResponse | string> {
-    let currentHour = new Date().getHours();
+export async function handler(): Promise<AWS.SES.SendEmailResponse | string> {
+  let currentHour = new Date().getHours();
 
-    let config = new Config();
+  let config = new Config();
 
-    let shouldRun = config.RunHours.indexOf(currentHour) >= 0;
+  let shouldRun = config.RunHours.indexOf(currentHour) >= 0;
 
-    if (shouldRun) return checkPublication(config);
-    else return Promise.resolve(`Not running because hour is ${currentHour}`)
+  if (shouldRun) return checkPublication(config, sendEmail(config));
+  else return Promise.resolve(`Not running because hour is ${currentHour}`);
 }
+
+let sendEmail = (config: Config) => (
+  subject: string,
+  body: string,
+  targetAddresses: string[]
+): Promise<AWS.SES.SendEmailResponse> => {
+  let request: AWS.SES.SendEmailRequest = {
+    Destination: {
+      ToAddresses: targetAddresses
+    },
+    Message: {
+      Subject: {
+        Charset: "UTF-8",
+        Data: subject
+      },
+      Body: {
+        Text: {
+          Charset: "UTF-8",
+          Data: body
+        }
+      }
+    },
+    Source: config.SourceAddress,
+    ReturnPath: config.ReturnPath
+  };
+
+  return ses.sendEmail(request).promise();
+};

--- a/src/local.ts
+++ b/src/local.ts
@@ -1,5 +1,6 @@
-import { handler } from './lambda';
-let AWS = require('aws-sdk');
+import { checkPublication } from "./checkPublication";
+import { Config } from "./config";
+let AWS = require("aws-sdk");
 
 /**
  * For testing locally:
@@ -12,10 +13,32 @@ AWS.config.secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 AWS.config.sessionToken = process.env.AWS_SESSION_TOKEN;
 AWS.config.region = "eu-west-1";
 
-async function run() {
-    await handler()
-        .then(result => console.log(result))
-        .catch(err => console.log(err))
+async function run(today) {
+  console.log(`Checking publication for ${today}`);
+
+  let config = new Config();
+  config.Today = today;
+
+  await checkPublication(config, sendEmail)
+    .then(result => console.log(result))
+    .catch(err => console.error(err));
 }
 
-run();
+async function sendEmail(
+  subject: string,
+  body: string,
+  targetAddresses: string[]
+): Promise<AWS.SES.SendEmailResponse> {
+  console.log(`Subject: ${subject}\n`);
+  console.log(body);
+  return Promise.resolve({
+    MessageId: "1234"
+  });
+}
+
+if (process.argv.length < 3) {
+  console.error("Run locally using: npm run local YYYY-MM-DD");
+  process.exit(-1);
+}
+
+run(process.argv[2]);


### PR DESCRIPTION
Checking that the number of published articles is above a certain threshold does not give enough information to diagnose the error. In this PR, we had a check before that one that will look into the logs for the last two runs and filter through the ones about failures. If there's any, an email will be sent with the exact content of those logs.

TODO
- [x] Make sure log streams belong to the day's logs
- [x] Loop over the log stream array