### PR TITLE
Apply DST logic

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -10,11 +10,15 @@ let ses = new AWS.SES({ region: "eu-west-1" });
  * Runs a series of checks against today's Kindle publication, then sends an email
  */
 export async function handler(): Promise<AWS.SES.SendEmailResponse | string> {
-  let currentHour = new Date().getHours();
+  const now = new Date();
+  
+  const currentHour = now.getHours();
+  const currentUTCHour = now.getUTCHours();
+  const isDST = currentHour == currentUTCHour + 1;
 
   let config = new Config();
 
-  let shouldRun = config.RunHours.indexOf(currentHour) >= 0;
+  let shouldRun = config.RunHours.indexOf(isDST ? currentHour : currentUTCHour) >= 0;
 
   if (shouldRun) return checkPublication(config, sendEmail(config));
   else return Promise.resolve(`Not running because hour is ${currentHour}`);

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -12,13 +12,12 @@ let ses = new AWS.SES({ region: "eu-west-1" });
 export async function handler(): Promise<AWS.SES.SendEmailResponse | string> {
   const now = new Date();
   
-  const currentHour = now.getHours();
-  const currentUTCHour = now.getUTCHours();
-  const isDST = currentHour == currentUTCHour + 1;
+  const currentHour = now.getUTCHours();
+  const isDST = now.getTimezoneOffset() > 0;
 
   let config = new Config();
 
-  let shouldRun = config.RunHours.indexOf(isDST ? currentHour : currentUTCHour) >= 0;
+  let shouldRun = config.RunHours.indexOf(isDST ? currentHour + 1 : currentHour) >= 0;
 
   if (shouldRun) return checkPublication(config, sendEmail(config));
   else return Promise.resolve(`Not running because hour is ${currentHour}`);


### PR DESCRIPTION
We know the lambda runs at 12am and 1am London time. We also know that:

- during DST, these times map to 11pm and 12am universtal time
- otherwise they map to the 12am and 1am universal time

So all we have to do is take the universal time and offset it by 1 hour when in DST. By using universal time, we also avoid the problem of dealing with hours that may not exist, e.g. 2am London time on Oct 31.