### PR TITLE
Add missing logs permissions

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -47,9 +47,6 @@ Parameters:
     Description: Timezone the environment should adopt (because cloudwatch only allows UTC)
     Type: String
     Default: "Europe/London"
-  KindleGenLogStreamArn:
-    Description: ARN for the log stream of the kindle generation process
-    Type: String
 Resources:
   Lambda:
     Type: AWS::Serverless::Function
@@ -98,7 +95,7 @@ Resources:
               - logs:GetLogEvents
               - logs:DescribeLogStreams
             Resource:
-              - !Ref KindleGenLogStreamArn
+              - "*"
 
       # These events run 6 mins after the kindle-gen lambda
       Events:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -47,6 +47,9 @@ Parameters:
     Description: Timezone the environment should adopt (because cloudwatch only allows UTC)
     Type: String
     Default: "Europe/London"
+  KindleGenLogStreamArn:
+    Description: ARN for the log stream of the kindle generation process
+    Type: String
 Resources:
   Lambda:
     Type: AWS::Serverless::Function
@@ -89,6 +92,13 @@ Resources:
             Condition:
               StringEquals:
                 ses:FromAddress: !Ref SourceAddress
+        - Statement:
+            Effect: Allow
+            Action:
+              - logs:GetLogEvents
+              - logs:DescribeLogStreams
+            Resource:
+              - !Ref KindleGenLogStreamArn
 
       # These events run 6 mins after the kindle-gen lambda
       Events:


### PR DESCRIPTION
Yesterday when upgrading to Node 10, the cloudformation was updated. This erased additional permissions that were grafted on the lambda role by someone via the AWS console, which broke the lambda when it ran. I couldn't go as far in my tests so I didn't see this happen.