### PR TITLE
Email cloudwatch error logs instead of redirect logs, if both are available

### DIFF
--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -176,7 +176,7 @@ export function checkPublication(
     allLogs: Array<AWS.CloudWatchLogs.OutputLogEvent>
   ): Promise<void> => {
     const errorRegexp = /WARN|ERROR|FATAL/;
-    const errors = allLogs.filter(log => errorRegexp.test(log.message));
+    const errors = allLogs.filter(log => errorRegexp.test(log.message)).map(log => log.message);
     if (errors.length > 0) {
       return Promise.reject(errors);
     } else {

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -204,16 +204,17 @@ export function checkPublication(
       config.FailureTargetAddresses
     );
 
-  return getRedirect(config.ManifestURL)
-    .then(testRedirect)
-    .then(() => getLogs(logGroupName).then(checkLogs))
-    .then(() =>
-      getS3Objects(
-        config.KindleBucket,
-        `${config.Stage}/${config.Today}/${currentHourString()}`
+  return getLogs(logGroupName)
+      .then(checkLogs)
+      .then(() => getRedirect(config.ManifestURL))
+      .then(testRedirect)
+      .then(() =>
+          getS3Objects(
+              config.KindleBucket,
+              `${config.Stage}/${config.Today}/${currentHourString()}`
+          )
       )
-    )
-    .then(validatePublicationInfo)
-    .then(sendSuccessEmail)
-    .catch(sendFailureEmail);
+      .then(validatePublicationInfo)
+      .then(sendSuccessEmail)
+      .catch(sendFailureEmail);
 }


### PR DESCRIPTION
## What does this change?
Recently we had an incident with Kindle where it failed to publish due to a file name being too long. This took more time than it should have done to diagnose as the error message in the failure email was not very descriptive:

`'Expected status code 302 (moved permanently) for url [redacted], got 404'`

Currently, whichever error is caught first in our publication check logic is sent in the failure email. By catching our cloudwatch error logs first, rather than our redirect errors, our failure emails will be more descriptive.

Note that this does not change the requirements for a failure email to be sent. Either a cloudwatch error log or redirect error will still cause a failure email to be sent.

Also note that a cloudwatch error log is likely to occur alongside a redirect error - this is why there have been so few emails with cloudwatch error logs until this point.

___


EDIT 06/07/2021: This PR also fixes [Object object] failure emails by passing the error message instead of the error object.

___

NB. We could potentially email *both* the redirect logs *and* the cloudwatch error logs, if they are available. If there is an appetite for this, we can restructure the publication logic. For me, the redirect logs are only useful if there are no cloudwatch error logs available, and the code here will email the redirect logs in that scenario.

## How to test
We don't have a CODE version of this lambda. We could spin one up, and test it there (linking it up to the CODE version of the kindle-gen lambda), or we could attempt to run this locally in a similar way.

## How can we measure success?
Emails should contain more descriptive, meaningful logs.

We should receive the same number of failure emails as before (ideally, of course, we would have none, but ho hey).

## Have we considered potential risks?
If `kindle-publication-check` is broken, we won't be notified when the kindle edition fails to publish. This change is minimal, so this scenario is unlikely.

One risk is that the error logs we receive from cloudwatch are less descriptive, not more - but the logs in the `kindle-gen` repo look good.