### PR TITLE
Add ability to manually trigger publication check

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -9,7 +9,7 @@ let ses = new AWS.SES({ region: "eu-west-1" });
  * The AWS Lambda handler function.
  * Runs a series of checks against today's Kindle publication, then sends an email
  */
-export async function handler(): Promise<AWS.SES.SendEmailResponse | string> {
+export async function handler(event: { forceRun? : boolean }): Promise<AWS.SES.SendEmailResponse | string> {
   const now = new Date();
   
   const currentHour = now.getUTCHours();
@@ -17,7 +17,7 @@ export async function handler(): Promise<AWS.SES.SendEmailResponse | string> {
 
   let config = new Config();
 
-  let shouldRun = config.RunHours.indexOf(isDST ? currentHour + 1 : currentHour) >= 0;
+  let shouldRun = !!event.forceRun || config.RunHours.indexOf(isDST ? currentHour + 1 : currentHour) >= 0;
 
   if (shouldRun) return checkPublication(config, sendEmail(config));
   else return Promise.resolve(`Not running because hour is ${currentHour}`);


### PR DESCRIPTION
## What does this change?
You should now be able to run this lambda by sending a test event from the AWS lambda console, with a payload of:

```
{
  "forceRun": "true"
}
```


## How to test
Tested on PROD environment (no CODE environment available) - email successfully delivered.

## How can we measure success?
Lambda should be triggered successfully, sending either a failure or success email to the CAPI team.

## Have we considered potential risks?
The type checkings could be incorrect, causing unforeseen errors. If this happens we can rollback.