### PR TITLE
Jp/rk/fix kindle clock change misery

### DIFF
--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -196,18 +196,18 @@ export function checkPublication(
     );
 
 
-  const addDays = function(days) {
-    let date = new Date();
-    date.setDate(date.getDate() + days);
-    return date;
-  }
-
   const buildPublicationErrorSubject = () : string => {
     let now = new Date();
+    let nextWeek = new Date();
+    nextWeek.setDate(now.getDate()+ 7)
+
+    // Check if it's Christmas Day - we do not expect a Kindle publication
     if (now.getMonth() === 11 && now.getDate() === 25) {
       return 'No kindle publication on Christmas Day. Merry Christmas!';
     }
-    else if (addDays(7).getMonth() === 3 && now.getDay() === 0 && now.getMonth() == 2 && now.getHours() === 2)
+    // Check if Kindle publication check failure is due to BST clock change:
+    // If today is Sunday and month is March and time is 2 am and next Sunday is in April (this is the last Sunday in March)
+    else if (now.getDay() === 0 && now.getMonth() == 2 && now.getHours() === 2 && nextWeek.getMonth() === 3)
     {
       return `Kindle publication check failed (${config.Today}) due to BST clock change`;
     }

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -195,9 +195,29 @@ export function checkPublication(
       config.PassTargetAddresses
     );
 
+
+  const addDays = function(days) {
+    let date = new Date();
+    date.setDate(date.getDate() + days);
+    return date;
+  }
+
+  const buildPublicationErrorSubject = () : string => {
+    let now = new Date();
+    if (now.getMonth() === 11 && now.getDate() === 25) {
+      return "No kindle publication on Christmas Day. Merry Christmas!"
+    }
+    else if (addDays(7).getMonth() === 3 && now.getDay() === 0 && now.getMonth() == 2 && now.getHours() === 2)
+    {
+      return `Kindle publication check failed (${config.Today}) due to BST clock change`
+    }
+    return `Kindle publication FAILED (${config.Today})`
+  }
+
+
   let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
     sendEmail(
-      `Kindle publication FAILED (${config.Today})`,
+      buildPublicationErrorSubject(),
       `The Kindle edition for ${
         config.Today
       } was not successfully published. The error was: \n'${error}'`,

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -205,13 +205,13 @@ export function checkPublication(
   const buildPublicationErrorSubject = () : string => {
     let now = new Date();
     if (now.getMonth() === 11 && now.getDate() === 25) {
-      return "No kindle publication on Christmas Day. Merry Christmas!"
+      return 'No kindle publication on Christmas Day. Merry Christmas!';
     }
     else if (addDays(7).getMonth() === 3 && now.getDay() === 0 && now.getMonth() == 2 && now.getHours() === 2)
     {
-      return `Kindle publication check failed (${config.Today}) due to BST clock change`
+      return `Kindle publication check failed (${config.Today}) due to BST clock change`;
     }
-    return `Kindle publication FAILED (${config.Today})`
+    return `Kindle publication FAILED (${config.Today})`;
   }
 
 

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -195,25 +195,30 @@ export function checkPublication(
       config.PassTargetAddresses
     );
 
+  const isChristmasDay = (today: Date) : boolean => {
+    return (today.getMonth() === 11 && today.getDate() === 25)
+  }
+
+  const isLastSundayInMarch = (today: Date) : boolean => {
+    // The last Sunday will definitely fall on one of the last 7 days of the month (March 25th - 31st)
+    return (today.getDay() === 0 && today.getMonth() == 2 && today.getDate() > 24)
+  }
 
   const buildPublicationErrorSubject = () : string => {
     let now = new Date();
-    let nextWeek = new Date();
-    nextWeek.setDate(now.getDate()+ 7)
+    let subject = `Kindle publication FAILED (${config.Today})`;
 
-    // Check if it's Christmas Day - we do not expect a Kindle publication
-    if (now.getMonth() === 11 && now.getDate() === 25) {
-      return 'No kindle publication on Christmas Day. Merry Christmas!';
+    if (isChristmasDay(now)) {
+      subject = 'No kindle publication on Christmas Day. Merry Christmas!';
     }
-    // Check if Kindle publication check failure is due to BST clock change:
-    // If today is Sunday and month is March and time is 2 am and next Sunday is in April (this is the last Sunday in March)
-    else if (now.getDay() === 0 && now.getMonth() == 2 && now.getHours() === 2 && nextWeek.getMonth() === 3)
-    {
-      return `Kindle publication check failed (${config.Today}) due to BST clock change`;
+
+    // On the last Sunday of March, we expect the second kindle check to fail due to BST clock change
+    else if (isLastSundayInMarch(now) && now.getHours() === 2) {
+      subject = `Kindle publication check failed (${config.Today}) due to BST clock change`;
     }
-    return `Kindle publication FAILED (${config.Today})`;
+
+    return subject;
   }
-
 
   let sendFailureEmail = (error: string): Promise<SendEmailResponse> =>
     sendEmail(


### PR DESCRIPTION
## What does this change?

This introduces more descriptive error email subjects in case of a Kindle failure on Christmas Day and on BST clock change day. This is to fix the issue of false alarms being raised on days where we expect the kindle publication check to fail.

## How to test

Tested locally with some manual date tests.

## How can we measure success?

No more false alarms.

## Have we considered potential risks?

This is a relatively low risk change.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
