### PR TITLE
Removes event trigger for kindle publication check

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -97,17 +97,3 @@ Resources:
             Resource:
               - "*"
 
-      # These events run 6 mins after the kindle-gen lambda
-      Events:
-        DailyGMTRun:
-          Type: Schedule
-          Properties:
-            Schedule: cron(16 1 * * ? *)  # Run at 01:16 AM GMT (UTC+0) every day
-        DailyBSTRunGMTPrerun:
-          Type: Schedule
-          Properties:
-            Schedule: cron(16 0 * * ? *)  # Run at 12:16 AM GMT (UTC+0) / 01:16 AM BST (UTC+1) every day
-        DailyBSTPrerun:
-          Type: Schedule
-          Properties:
-            Schedule: cron(16 23 * * ? *)  # Run at 12:16 AM BST (UTC+1) every day

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -187,8 +187,6 @@ export function checkPublication(
     );
   };
 
-
-
   const sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
     sendEmail(
       `Kindle publication succeeded (${config.Today})`,

--- a/src/checkPublication.ts
+++ b/src/checkPublication.ts
@@ -187,6 +187,8 @@ export function checkPublication(
     );
   };
 
+
+
   const sendSuccessEmail = (info: PublicationInfo): Promise<SendEmailResponse> =>
     sendEmail(
       `Kindle publication succeeded (${config.Today})`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We're putting the Kindle edition to sleep, therefore there is no need for this publication check to run. If it does run, it will trigger an alarm due to the Kindle edition not existing.

## How to test
Update cloudformation and make sure that the event trigger is removed.

## How can we measure success?

Lambda doesn't run and doesn't send any failure emails.

